### PR TITLE
Remove js error with undefined object.

### DIFF
--- a/view/include/video.php
+++ b/view/include/video.php
@@ -265,6 +265,9 @@ if (!empty($autoPlayVideo)) {
                                     });
                                     // in case the video is muted
                                     setTimeout(function () {
+										if (typeof player === 'undefined') {
+											player = videojs('mainVideo');
+										}
                                         if (player.muted()) {
                                             swal({
                                                 title: "<?php echo __("Your Media is Muted"); ?>",


### PR DESCRIPTION
Without this redefinition of object, sometimes error is thrown in console.